### PR TITLE
Add Yume as an MCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A curated list of awesome Model Context Protocol (MCP) clients.
     - [Witsy](#witsy)
     - [Enconvo](#enconvo)
     - [y-cli](#y-cli)
+    - [Yume](#yume)
     - [Zed](#zed)
     - [MindPal](#mindpal)
     - [WhatsMCP](#whatsmcp)
@@ -1672,6 +1673,20 @@ A tiny command-line interface chat application that brings AI conversations to y
 ![MCP Demo](./screenshots/y-cli/mcp.gif)
 
 </details>
+
+### Yume
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/aofp/yume</td></tr>
+<tr><th align="left">Website</th><td>https://aofp.github.io/yume/</td></tr>
+<tr><th align="left">License</th><td>Proprietary</td></tr>
+<tr><th align="left">Type</th><td>Desktop app</td></tr>
+<tr><th align="left">Platforms</th><td>MacOS, Windows, Linux</td></tr>
+<tr><th align="left">Pricing</th><td>Free</td></tr>
+<tr><th align="left">Programming Languages</th><td>Rust, TypeScript</td></tr>
+</table>
+
+Desktop GUI for Claude Code with built-in MCP server management, custom MCP memory server (yume-mcp-memory), multi-tab sessions, background agents, and plugin system.
 
 ### Zed
 


### PR DESCRIPTION
## Add Yume

Adds [Yume](https://github.com/aofp/yume) to the MCP clients list.

**Yume** is a Tauri 2.x desktop GUI for Claude Code (Rust + TypeScript) with:
- Built-in MCP server management (add/remove/configure MCP servers)
- Custom MCP memory server (`yume-mcp-memory`) for persistent per-project memory
- Multi-tab sessions with background agents
- Plugin system supporting MCP server integration

| Field | Value |
|-------|-------|
| GitHub | https://github.com/aofp/yume |
| Website | https://aofp.github.io/yume/ |
| License | Proprietary |
| Type | Desktop app |
| Platforms | macOS, Windows, Linux |
| Pricing | Free |
| Languages | Rust, TypeScript |