### PR TITLE
fix(README): correct fastchat-mcp html

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,9 @@ Future versions are expected to include additional features such as voice system
 <summary>Screenshots</summary>
 
 <https://github.com/user-attachments/assets/1fcb0db8-5798-4745-8711-4b93198e36cc>
+
+</details>
+
 ### Enola
 
 <table>


### PR DESCRIPTION
The `<details>` tag was unclosed for fastchat-mcp which resulted in the rest of the page not rendering properly.