### PR TITLE
Add Claude Code Open to MCP clients list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A curated list of awesome Model Context Protocol (MCP) clients.
     - [ChatMCP](#chatmcp)
     - [Cherry Studio](#cherry-studio)
     - [Claude Desktop](#claude-desktop)
+    - [Claude Code Open](#claude-code-open)
     - [ClaudeMind](#claudemind)
     - [Cline](#cline)
     - [console-chat-gpt](#console-chat-gpt)
@@ -421,6 +422,20 @@ The Claude desktop app brings Claude's capabilities directly to your computer, a
 ![](./screenshots/claude-desktop/claude-desktop.png)
 
 </details>
+
+### Claude Code Open
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/kill136/claude-code-open</td></tr>
+<tr><th align="left">Website</th><td>-</td></tr>
+<tr><th align="left">License</th><td>MIT</td></tr>
+<tr><th align="left">Type</th><td>CLI, Web IDE</td></tr>
+<tr><th align="left">Platforms</th><td>Windows, MacOS, Linux</td></tr>
+<tr><th align="left">Pricing</th><td>Free</td></tr>
+<tr><th align="left">Programming Languages</th><td>TypeScript</td></tr>
+</table>
+
+Open-source AI coding platform based on Claude Code CLI with full MCP protocol support. Features a browser-based Web IDE with Monaco editor, 37+ built-in tools, Blueprint multi-agent orchestration system, and scheduled task daemon. Supports MCP server configuration and integration for extending AI capabilities through external tools and services.
 
 ### ClaudeMind
 


### PR DESCRIPTION
## Description

Adding [Claude Code Open](https://github.com/kill136/claude-code-open) to the MCP clients list.

Claude Code Open is an open-source AI coding platform based on Claude Code CLI with full MCP protocol support. It features:

- **MCP Integration**: Full MCP protocol support for connecting to external MCP servers
- **Web IDE**: Browser-based IDE with Monaco editor
- **37+ Built-in Tools**: File operations, code analysis, web access, system commands, and more
- **Multi-Agent System**: Blueprint orchestration for complex multi-step tasks
- **Cross-Platform**: Works on Windows, macOS, and Linux

**License**: MIT  
**Language**: TypeScript  
**GitHub**: https://github.com/kill136/claude-code-open