### PR TITLE
Add Promptise Foundry 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A curated list of awesome Model Context Protocol (MCP) clients.
     - [Zin MCP Client](#zin-mcp-client)
     - [Qordinate](#qordinate)
     - [PraisonAI](#praisonai)
+    - [Promptise Foundry](#promptise-foundry)
   - [Servers](#servers)
 
 ### OpenClaw
@@ -2144,6 +2145,22 @@ Qordinate is a personal assistant that talks on your behalf, it knows what to sh
 </table>
 
 PraisonAI is a production-ready Multi-AI Agents framework with native MCP integration. Features fastest agent instantiation (3.77μs), 100+ LLM support via LiteLLM, agentic workflows (route/parallel/loop/repeat), built-in memory, and self-reflection. Available as Python & JavaScript SDKs.
+
+### Promptise Foundry
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/promptise-com/foundry</td></tr>
+<tr><th align="left">Website</th><td>https://promptise.com</td></tr>
+<tr><th align="left">License</th><td>Apache-2.0</td></tr>
+<tr><th align="left">Type</th><td>Python library, SDK</td></tr>
+<tr><th align="left">Platforms</th><td>Windows, macOS, Linux</td></tr>
+<tr><th align="left">Pricing</th><td>Free / Open Source</td></tr>
+<tr><th align="left">Programming Languages</th><td>Python</td></tr>
+</table>
+
+**Promptise Foundry** is a production-grade Python agent framework with a native MCP client implementation (no third-party MCP client dependencies). It supports all three MCP transports — stdio, SSE, and streamable HTTP — plus bearer-token and API-key authentication. `MCPClient` connects to a single server; `MCPMultiClient` fans out across N servers with unified tool discovery and automatic routing; `MCPToolAdapter` converts MCP tools into LangChain `BaseTool` instances with recursive JSON-Schema handling. The framework is most commonly used through `build_agent()`, which auto-discovers tools from one or more MCP server URLs, wires them into an LLM of your choice (OpenAI, Anthropic, Ollama, or any LangChain `BaseChatModel`), and handles memory, guardrails, conversation persistence, and cross-agent delegation out of the box.
+
+`pip install promptise`
 
 ## Servers
 


### PR DESCRIPTION
Adds **[Promptise Foundry](https://github.com/promptise-com/foundry)** — a production-grade Python agent framework with a native MCP client implementation.

### Why it belongs on this list

- **Native MCP client** (no third-party MCP client deps) — `MCPClient`, `MCPMultiClient`, `MCPToolAdapter`
- **All three transports**: stdio, SSE, streamable HTTP
- **Auth**: bearer tokens + API keys
- **Multi-server routing**: `MCPMultiClient` unifies tool discovery across N servers with automatic routing
- **LangChain bridge**: `MCPToolAdapter` converts MCP tools → LangChain `BaseTool` with recursive JSON-Schema handling
- **Agent-friendly**: typically consumed via `build_agent()`, which auto-discovers tools from one or more MCP server URLs and plugs them into any LLM (OpenAI, Anthropic, Ollama, or any LangChain `BaseChatModel`)

### Format compliance

- Entry uses the standard `### Heading` + metadata `<table>` + descriptive paragraph format (matches the `askit-mcp` template as the closest analog — Python client library)
- Metadata table includes GitHub, Website, License (Apache-2.0), Type, Platforms (Windows/macOS/Linux), Pricing (Free / Open Source), Programming Languages (Python)
- Added to the TOC in the same spot (after `PraisonAI`)
- One client per line, concise description, accurate links

License: Apache-2.0.