### PR TITLE
Add MateClaw client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,20 @@ Save playbooks:
 ![](./screenshots/lutra/create-playbook.gif)
 </details>
 
+### MateClaw
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/matevip/mateclaw</td></tr>
+<tr><th align="left">Website</th><td>https://claw.mate.vip</td></tr>
+<tr><th align="left">License</th><td>Apache-2.0</td></tr>
+<tr><th align="left">Type</th><td>Self-hosted AI Agent</td></tr>
+<tr><th align="left">Platforms</th><td>Linux, Windows, MacOS, Docker</td></tr>
+<tr><th align="left">Pricing</th><td>Free</td></tr>
+<tr><th align="left">Programming Languages</th><td>Java, TypeScript</td></tr>
+</table>
+
+**MateClaw** is an open-source personal AI operating system built on Spring Boot 3.5 + Spring AI Alibaba. The same agent answers in a web admin console, a desktop app (bundled JRE 21), an embeddable widget, and 8 IM channels (DingTalk, Feishu, WeChat Work, WeChat, Telegram, Discord, QQ, Slack). Connects to MCP servers over **stdio**, **SSE**, and **Streamable HTTP** transports — wire a server URL, and the registered tools become available to every agent, gated by a Tool Guard layer with RBAC and approval flow. Also bundles ReAct + Plan-and-Execute agents on a StateGraph runtime, an LLM Wiki with per-sentence citations, a memory lifecycle (extract / consolidate / dream), and multi-vendor LLM failover.
+
 ### mcp-agent
 
 <table>


### PR DESCRIPTION
## Summary

Adds **MateClaw** as a new MCP client entry, inserted alphabetically between **Lutra** and **mcp-agent**.

## What MateClaw is

MateClaw is an open-source (Apache 2.0) personal AI operating system built on Spring Boot 3.5 + Spring AI Alibaba. The same agent answers in a web admin console, a desktop app (with bundled JRE 21), an embeddable widget, and 8 IM channels (DingTalk, Feishu, WeChat Work, WeChat, Telegram, Discord, QQ, Slack) — sharing the same memory and tools.

## MCP integration

- Connects to MCP servers over **three transports**: stdio, SSE, and Streamable HTTP.
- MCP server config UI in the admin console — paste a URL, select transport, registered tools become available to every agent in the workspace.
- Tools surfaced through MCP go through the same **Tool Guard** layer as built-in tools — RBAC, per-tool enable/disable, optional approval flow for sensitive calls.
- MCP-Skill bridge: skills can wrap MCP tools and surface them as installable Skill cards in the marketplace.

## Stats

- 363 stars · 116 forks · 137 published releases since 2026-04-04 · daily commits
- Apache 2.0 · Java backend, TypeScript/Vue 3 frontend
- Bilingual docs (English + Simplified Chinese)

## Links

- Repo: https://github.com/matevip/mateclaw
- Documentation: https://claw.mate.vip/docs
- Live demo: https://claw-demo.mate.vip
- Releases: https://github.com/matevip/mateclaw/releases

## Notes

- Followed the existing `### Name` + HTML metadata table + description format.
- Skipped the optional `<details>Screenshots</details>` block for now (matches the OpenClaw entry style); can add screenshots in a follow-up if useful.