### PR TITLE
Add Squadron - a declarative multi-agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A curated list of awesome Model Context Protocol (MCP) clients.
     - [Superinterface](#superinterface)
     - [SeekChat](#seekchat)
     - [Simple AI](#simple-ai)
+    - [Squadron](#squadron)
     - [Tambo](#tambo)
     - [Taskade](#taskade)
     - [Tester MCP Client](#tester-mcp-client)
@@ -1576,6 +1577,20 @@ Simple AI (simple-ai-io) is a command-based web/cli application, supports MCP.
 ![](./screenshots/simple-ai-chat/fetch.png)
 
 </details>
+
+### Squadron
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/mlund01/squadron</td></tr>
+<tr><th align="left">Website</th><td>https://docs.squadron.sh</td></tr>
+<tr><th align="left">License</th><td>MIT</td></tr>
+<tr><th align="left">Type</th><td>CLI, single binary</td></tr>
+<tr><th align="left">Platforms</th><td>macOS, Linux, Windows</td></tr>
+<tr><th align="left">Pricing</th><td>Free</td></tr>
+<tr><th align="left">Programming Languages</th><td>Go</td></tr>
+</table>
+
+[Squadron](http://docs.squadron.sh) is a declarative framework for defining and running multi-agent AI workflows. It is the terraform of multi-agent frameworks, and consumes any MCP server (npm packages, GitHub release binaries, HTTP, or local stdio) with two lines of HCL config. Auto-install is handled for npm and GitHub sources, including OAuth login for hosted servers (`squadron mcp login`).
 
 ### SwarmClaw
 


### PR DESCRIPTION
Adds Squadron to the Clients section.

Squadron is a Go-based, MIT-licensed multi-agent AI framework that
consumes MCP servers natively — declare any MCP source (npm, GitHub
release, HTTP, or local stdio) in two lines of HCL, and Squadron
auto-installs and proxies the server's tools to agents. OAuth login
flow handled for hosted servers via `squadron mcp login`.

- Repo: https://github.com/mlund01/squadron
- Docs: https://docs.squadron.sh
- MCP integration docs: https://docs.squadron.sh/config/mcp_tools

Follows the established table + paragraph format used by neighboring
client entries.