### PR TITLE
Add weave (TypeScript MCP-native agent orchestrator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,20 @@ Witsy is an AI desktop assistant supporting models from all major providers and 
 
 </details>
 
+### weave
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/polymatx/weave</td></tr>
+<tr><th align="left">Website</th><td>https://polymatx.dev/weave/</td></tr>
+<tr><th align="left">License</th><td>MIT</td></tr>
+<tr><th align="left">Type</th><td>Framework / SDK</td></tr>
+<tr><th align="left">Platforms</th><td>Node.js 22+ (cross-platform)</td></tr>
+<tr><th align="left">Pricing</th><td>Free / open source</td></tr>
+<tr><th align="left">Programming Languages</th><td>TypeScript</td></tr>
+</table>
+
+TypeScript-native multi-agent orchestrator that consumes MCP servers as first-class tools. Includes graph-based flows with typed state, SQLite checkpoints, USD budget guardrails, streaming agents, and a built-in local trace UI.
+
 ### Enconvo
 
 <table>


### PR DESCRIPTION
## What

Adds an entry for [polymatx/weave](https://github.com/polymatx/weave) — a TypeScript-native multi-agent orchestration framework that consumes MCP servers as first-class tools.

## Why this fits

Weave is an MCP **client** in the truest sense: `connectMcpServers({...})` uses `@modelcontextprotocol/sdk` to talk to any stdio or SSE MCP server, and the returned `tools` object plugs directly into an agent definition. Each MCP tool's input schema is auto-converted from JSON Schema to Zod, preserving strict typing in the agent's tool calls.

Highlights:

- Type-safe graph state with conditional edges
- Streaming agents with per-token trace events
- SQLite checkpoints (durable runs that resume after crash)
- USD budget enforcement with a kill switch
- Local trace dashboard (Hono + React) shipped in the same repo

## Format check

- [x] Entry follows the established table-style format
- [x] Placed alphabetically (W → weave) after Witsy
- [x] Description fits on a single paragraph
- [x] Live docs at https://polymatx.dev/weave/
- [x] Published on npm under `@polymatx/weave`, `@polymatx/weave-mcp`, `@polymatx/weave-ui`

Happy to adjust positioning or description style if it doesn't match house conventions.