### PR TITLE
Add mcpm (mcp-forge) — universal MCP server package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -2188,6 +2188,24 @@ Qordinate is a personal assistant that talks on your behalf, it knows what to sh
 
 PraisonAI is a production-ready Multi-AI Agents framework with native MCP integration. Features fastest agent instantiation (3.77μs), 100+ LLM support via LiteLLM, agentic workflows (route/parallel/loop/repeat), built-in memory, and self-reflection. Available as Python & JavaScript SDKs.
 
+### mcpm (mcp-forge)
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/AZERDSQ131/mcp-forge</td></tr>
+<tr><th align="left">Website</th><td>https://azerdsq131.github.io/mcp-forge</td></tr>
+<tr><th align="left">License</th><td>MIT</td></tr>
+<tr><th align="left">Type</th><td>CLI / Package Manager</td></tr>
+<tr><th align="left">Platforms</th><td>Windows, MacOS, Linux</td></tr>
+<tr><th align="left">Pricing</th><td>Free</td></tr>
+<tr><th align="left">Programming Languages</th><td>TypeScript</td></tr>
+</table>
+
+Universal MCP server package manager. Installs and configures MCP servers across all AI clients (Claude Code, Cursor, VS Code Copilot, Windsurf, Zed, Codex, Gemini CLI) automatically. 1000+ servers in the registry. Supports npm (npx), Python (uvx), Docker, Go, and Deno runtimes. Team sync via `.mcpmrc` project file.
+
+```bash
+npx mcp-fleet install github postgres stripe
+```
+
 ## Servers
 
 Looking for MCP servers? Check out the [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) repository.


### PR DESCRIPTION
**mcpm** is a universal CLI package manager for MCP servers — think npm, but for MCP.

One command installs and auto-configures servers across all AI clients simultaneously:

```bash
npx mcp-fleet install github postgres stripe
```

**Why it fits this list:** mcpm manages MCP client configurations (Claude Code, Cursor, VS Code Copilot, Windsurf, Zed, Codex, Gemini CLI) — it's the glue layer between servers and clients.

- 1000+ servers in the built-in registry
- Multi-runtime: npm (npx), Python (uvx), Docker, Go, Deno  
- Team sync via `.mcpmrc` project file
- MIT, active development

GitHub: https://github.com/AZERDSQ131/mcp-forge