### PR TITLE
Add ozr security-first MCP agent harness 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,6 +1466,20 @@ A terminal client for Ollama, with support for MCP servers.
 
 </details>
 
+### ozr
+
+<table>
+<tr><th align="left">GitHub</th><td>https://github.com/kenjiroe/ozr</td></tr>
+<tr><th align="left">Website</th><td>https://github.com/kenjiroe/ozr#readme</td></tr>
+<tr><th align="left">License</th><td>MIT</td></tr>
+<tr><th align="left">Type</th><td>CLI, HTTP API, Desktop (Tauri beta)</td></tr>
+<tr><th align="left">Platforms</th><td>Windows, macOS, Linux</td></tr>
+<tr><th align="left">Pricing</th><td>Free</td></tr>
+<tr><th align="left">Programming Languages</th><td>Rust</td></tr>
+</table>
+
+Security-first, local-first async agent harness for MCP. Rust + Tokio runtime with human approval gates, policy packs, sandboxd isolation, OpenAI-compatible API with live SSE streaming, memory recall eval, and optional Tauri GUI (beta). Unknown tools escalate to Shell (never auto-approved).
+
 ### Slack MCP Client
 
 <table>

--- a/README.md
+++ b/README.md
@@ -1473,7 +1473,7 @@ A terminal client for Ollama, with support for MCP servers.
 <tr><th align="left">Website</th><td>https://github.com/kenjiroe/ozr#readme</td></tr>
 <tr><th align="left">License</th><td>MIT</td></tr>
 <tr><th align="left">Type</th><td>CLI, HTTP API, Desktop (Tauri beta)</td></tr>
-<tr><th align="left">Platforms</th><td>Windows, macOS, Linux</td></tr>
+<tr><th align="left">Platforms</th><td>Windows, MacOS, Linux</td></tr>
 <tr><th align="left">Pricing</th><td>Free</td></tr>
 <tr><th align="left">Programming Languages</th><td>Rust</td></tr>
 </table>


### PR DESCRIPTION
Adds [ozr](https://github.com/kenjiroe/ozr) — security-first Rust MCP agent harness with human approval gates, policy packs, sandboxd isolation, OpenAI-compatible API with live SSE streaming, memory recall eval, and optional Tauri GUI (beta). Unknown tools escalate to Shell (never auto-approved).

Inserted alphabetically after `### oterm`, before `### Slack MCP Client`.

Made with [Cursor](https://cursor.com)